### PR TITLE
[#IC-236] Add Application Insight

### DIFF
--- a/OnServiceChange/__tests__/handler.test.ts
+++ b/OnServiceChange/__tests__/handler.test.ts
@@ -71,7 +71,9 @@ const mockGetClient = () => ({
 const mockApimClient = {
   getClient: mockGetClient
 };
-
+const mockTelemtryClient = {
+  trackEvent: jest.fn()
+};
 const mockQueryResult = {
   command: "INSERT",
   rowCount: 1
@@ -192,8 +194,8 @@ describe("storeDocumentApimToDatabase", () => {
       apimClient,
       mockConfig as any,
       mockClientPool,
-      mockDocuments[0] as any
-    )();
+      mockTelemtryClient as any
+    )(mockDocuments[0] as any)();
     expect(isRight(res)).toBe(true);
     if (isRight(res)) {
       expect(res.right).toBe(undefined);
@@ -209,8 +211,8 @@ describe("storeDocumentApimToDatabase", () => {
       (apimClient as unknown) as ApiManagementClient,
       mockConfig as any,
       mockClientPool,
-      mockDocuments[0] as any
-    )();
+      mockTelemtryClient as any
+    )(mockDocuments[0] as any)();
     expect(isRight(res)).toBe(true);
     if (isRight(res)) {
       expect(res.right).toHaveProperty("command", "INSERT");

--- a/OnServiceChange/handler.ts
+++ b/OnServiceChange/handler.ts
@@ -36,6 +36,7 @@ import {
   mapPostgreSQLError
 } from "../utils/mapError";
 import { initTelemetryClient } from "../utils/appinsight";
+import { onIgnoredDocument, onInvalidDocument } from "../utils/tracking";
 
 export const validateDocument = (
   document: unknown
@@ -177,33 +178,6 @@ export const createUpsertSql = (dbConfig: IDecodableConfigPostgreSQL) => (
 
 export const log = (d: unknown): void => {
   throw new Error(`To be implement ${d}`);
-};
-
-export const onInvalidDocument = (
-  telemetryClient: ReturnType<typeof initTelemetryClient>
-) => (d: unknown): void => {
-  telemetryClient.trackEvent({
-    name: "selfcare.subsmigrations.services.oninvaliddocument",
-    properties: {
-      documentId: (d as RetrievedService).serviceId,
-      message: "Invalid document received"
-    },
-    tagOverrides: { samplingEnabled: "false" }
-  });
-};
-
-export const onIgnoredDocument = (
-  telemetryClient: ReturnType<typeof initTelemetryClient>
-) => (d: unknown): void => {
-  telemetryClient.trackEvent({
-    name: "selfcare.subsmigrations.services.onignoredocument",
-    properties: {
-      documentId: (d as RetrievedService).serviceId,
-      message: "Ignore document"
-    },
-    tagOverrides: { samplingEnabled: "false" }
-  });
-  return void 0;
 };
 
 export const storeDocumentApimToDatabase = (

--- a/OnServiceChange/handler.ts
+++ b/OnServiceChange/handler.ts
@@ -184,7 +184,7 @@ export const onInvalidDocument = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
 ): T.Task<void> => {
   telemetryClient.trackEvent({
-    name: "selfcare.services.oninvaliddocument",
+    name: "selfcare.subsmigrations.services.oninvaliddocument",
     properties: {
       documentId: (d as RetrievedService).serviceId,
       message: "Invalid document received"
@@ -199,7 +199,7 @@ export const onIgnoredDocument = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
 ): void => {
   telemetryClient.trackEvent({
-    name: "selfcare.services.onignoredocument",
+    name: "selfcare.subsmigrations.services.onignoredocument",
     properties: {
       documentId: (d as RetrievedService).serviceId,
       message: "Ignore document"
@@ -239,7 +239,7 @@ export const storeDocumentApimToDatabase = (
                 sql => queryDataTable(pool, sql),
                 res => {
                   telemetryClient.trackEvent({
-                    name: "selfcare.services.processeddocument",
+                    name: "selfcare.subsmigrations.services.processeddocument",
                     properties: {
                       difference: Math.floor(
                         // Cosmos store ts in second so we need to translate in milliseconds

--- a/OnServiceChange/handler.ts
+++ b/OnServiceChange/handler.ts
@@ -180,9 +180,8 @@ export const log = (d: unknown): void => {
 };
 
 export const onInvalidDocument = (
-  d: unknown,
   telemetryClient: ReturnType<typeof initTelemetryClient>
-): T.Task<void> => {
+) => (d: unknown): T.Task<void> => {
   telemetryClient.trackEvent({
     name: "selfcare.subsmigrations.services.oninvaliddocument",
     properties: {
@@ -195,9 +194,8 @@ export const onInvalidDocument = (
 };
 
 export const onIgnoredDocument = (
-  d: unknown,
   telemetryClient: ReturnType<typeof initTelemetryClient>
-): void => {
+) => (d: unknown): void => {
   telemetryClient.trackEvent({
     name: "selfcare.subsmigrations.services.onignoredocument",
     properties: {
@@ -256,7 +254,7 @@ export const storeDocumentApimToDatabase = (
               )
             : // processing is successful, just ignore the document
               TE.of<DomainError, QueryResult | void>(
-                onIgnoredDocument(retrievedDocument, telemetryClient)
+                onIgnoredDocument(telemetryClient)(retrievedDocument)
               )
         )
       )
@@ -280,7 +278,7 @@ export const createServiceChangeHandler = (
     RA.map(validateDocument),
     RA.map(
       E.fold(
-        document => onInvalidDocument(document, telemetryClient),
+        document => onInvalidDocument(telemetryClient)(document),
         flow(
           document =>
             storeDocumentApimToDatabase(

--- a/OnServiceChange/handler.ts
+++ b/OnServiceChange/handler.ts
@@ -244,8 +244,7 @@ export const storeDocumentApimToDatabase = (
                       difference: Math.floor(
                         // Cosmos store ts in second so we need to translate in milliseconds
                         // eslint-disable-next-line no-underscore-dangle
-                        (new Date().getTime() - retrievedDocument._ts * 1000) /
-                          (1000 * 3600 * 24)
+                        new Date().getTime() - retrievedDocument._ts * 1000
                       ),
                       message: "Processed document",
                       serviceId: retrievedDocument.serviceId

--- a/OnServiceChange/handler.ts
+++ b/OnServiceChange/handler.ts
@@ -39,7 +39,7 @@ import {
 import { initTelemetryClient } from "../utils/appinsight";
 import {
   trackIgnoredIncomingDocument,
-  trackIgnoredInvalidIncomingDocument,
+  trackInvalidIncomingDocument,
   trackProcessedServiceDocument
 } from "../utils/tracking";
 
@@ -245,10 +245,7 @@ export const createServiceChangeHandler = (
         validateDocument,
         E.mapLeft(err => {
           const reason = readableReport(err);
-          trackIgnoredInvalidIncomingDocument(telemetryClient)(
-            document,
-            reason
-          );
+          trackInvalidIncomingDocument(telemetryClient)(document, reason);
           return err;
         })
       )

--- a/OnServiceChange/handler.ts
+++ b/OnServiceChange/handler.ts
@@ -186,7 +186,7 @@ export const onInvalidDocument = (
   telemetryClient.trackEvent({
     name: "selfcare.services.oninvaliddocument",
     properties: {
-      document: d,
+      documentId: (d as RetrievedService).serviceId,
       message: "Invalid document received"
     },
     tagOverrides: { samplingEnabled: "false" }
@@ -201,7 +201,7 @@ export const onIgnoredDocument = (
   telemetryClient.trackEvent({
     name: "selfcare.services.onignoredocument",
     properties: {
-      document: d,
+      documentId: (d as RetrievedService).serviceId,
       message: "Ignore document"
     },
     tagOverrides: { samplingEnabled: "false" }

--- a/OnServiceChange/handler.ts
+++ b/OnServiceChange/handler.ts
@@ -181,7 +181,7 @@ export const log = (d: unknown): void => {
 
 export const onInvalidDocument = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
-) => (d: unknown): T.Task<void> => {
+) => (d: unknown): void => {
   telemetryClient.trackEvent({
     name: "selfcare.subsmigrations.services.oninvaliddocument",
     properties: {
@@ -190,7 +190,6 @@ export const onInvalidDocument = (
     },
     tagOverrides: { samplingEnabled: "false" }
   });
-  throw new Error(`To be implement ${JSON.stringify(d, null, 2)}`);
 };
 
 export const onIgnoredDocument = (
@@ -278,7 +277,7 @@ export const createServiceChangeHandler = (
     RA.map(validateDocument),
     RA.map(
       E.fold(
-        document => onInvalidDocument(telemetryClient)(document),
+        document => T.of(onInvalidDocument(telemetryClient)(document)),
         flow(
           document =>
             storeDocumentApimToDatabase(

--- a/OnServiceChange/index.ts
+++ b/OnServiceChange/index.ts
@@ -1,11 +1,15 @@
 import { getConfigOrThrow } from "../utils/config";
 import clientDB from "../utils/dbconnector";
 import { getApiClient } from "../utils/apim";
+import { initTelemetryClient } from "../utils/appinsight";
 import { createServiceChangeHandler } from "./handler";
 
 const config = getConfigOrThrow();
 
-// istanzio il client Post Pool
+// Setup Appinsight
+const telemetryClient = initTelemetryClient(config);
+
+// Setup PostgreSQL DB Pool
 const client = clientDB(config);
 const apimClient = getApiClient(
   {
@@ -19,7 +23,8 @@ const apimClient = getApiClient(
 const handleServicesChange = createServiceChangeHandler(
   config,
   apimClient,
-  client
+  client,
+  telemetryClient
 );
 
 export default handleServicesChange;

--- a/env.example
+++ b/env.example
@@ -28,5 +28,10 @@ APIM_CLIENT_ID="Your-Apim-Client-ID"
 APIM_SECRET="Your-Apim-Secret"
 APIM_TENANT_ID="Your-Apim-Tenant-ID"
 
+# Application Insight
+APPINSIGHTS_INSTRUMENTATIONKEY=""
+APPINSIGHTS_DISABLE=false
+APPINSIGHTS_SAMPLING_PERCENTAGE=100
+
 # needed to connect to cosmosdb server
 NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@pagopa/express-azure-functions": "^2.0.0",
     "@pagopa/io-functions-commons": "^21",
     "@pagopa/ts-commons": "^10.0.1",
+    "applicationinsights": "^2.2.1",
     "azure-storage": "^2.10.3",
     "durable-functions": "^1.4.4",
     "express": "^4.15.3",

--- a/utils/appinsight.ts
+++ b/utils/appinsight.ts
@@ -1,0 +1,14 @@
+import * as ai from "applicationinsights";
+import { initAppInsights } from "@pagopa/ts-commons/lib/appinsights";
+import { IConfig } from "./config";
+
+// Avoid to initialize Application Insights more than once
+export const initTelemetryClient = (
+  env: IConfig
+): ai.TelemetryClient | ReturnType<typeof initAppInsights> =>
+  ai.defaultClient
+    ? ai.defaultClient
+    : initAppInsights(env.APPINSIGHTS_INSTRUMENTATIONKEY, {
+        disableAppInsights: env.APPINSIGHTS_DISABLE === "true",
+        samplingPercentage: env.APPINSIGHTS_SAMPLING_PERCENTAGE
+      });

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -13,7 +13,10 @@ import { pipe } from "fp-ts/lib/function";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { withDefault } from "@pagopa/ts-commons/lib/types";
-import { NumberFromString } from "@pagopa/ts-commons/lib/numbers";
+import {
+  IntegerFromString,
+  NumberFromString
+} from "@pagopa/ts-commons/lib/numbers";
 
 // Environment configuration to connect to IO CosmosDB
 //   needed in order to fetch changes on Services collection
@@ -57,11 +60,23 @@ export const IDecodableConfigPostgreSQL = t.interface({
   DB_USER: NonEmptyString
 });
 
+// Environment configuration to connect to Application Insight instance
+//   needed in order to monitoring basic events and custom events
+export type IDecodableConfigAppInsight = t.TypeOf<
+  typeof IDecodableConfigAppInsight
+>;
+export const IDecodableConfigAppInsight = t.interface({
+  APPINSIGHTS_DISABLE: NonEmptyString,
+  APPINSIGHTS_INSTRUMENTATIONKEY: NonEmptyString,
+  APPINSIGHTS_SAMPLING_PERCENTAGE: withDefault(IntegerFromString, 5)
+});
+
 export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.intersection([
   IDecodableConfigCosmosDB,
   IDecodableConfigAPIM,
   IDecodableConfigPostgreSQL,
+  IDecodableConfigAppInsight,
   t.interface({
     // default function app storage connection
     AzureWebJobsStorage: NonEmptyString,

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -65,11 +65,15 @@ export const IDecodableConfigPostgreSQL = t.interface({
 export type IDecodableConfigAppInsight = t.TypeOf<
   typeof IDecodableConfigAppInsight
 >;
-export const IDecodableConfigAppInsight = t.interface({
-  APPINSIGHTS_DISABLE: NonEmptyString,
-  APPINSIGHTS_INSTRUMENTATIONKEY: NonEmptyString,
-  APPINSIGHTS_SAMPLING_PERCENTAGE: withDefault(IntegerFromString, 5)
-});
+export const IDecodableConfigAppInsight = t.intersection([
+  t.interface({
+    APPINSIGHTS_INSTRUMENTATIONKEY: NonEmptyString
+  }),
+  t.partial({
+    APPINSIGHTS_DISABLE: NonEmptyString,
+    APPINSIGHTS_SAMPLING_PERCENTAGE: withDefault(IntegerFromString, 5)
+  })
+]);
 
 export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.intersection([

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -27,3 +27,21 @@ export const onIgnoredDocument = (
   });
   return void 0;
 };
+
+export const onProcessedDocument = (
+  telemetryClient: ReturnType<typeof initTelemetryClient>
+) => (retrievedDocument: RetrievedService): void => {
+  telemetryClient.trackEvent({
+    name: "selfcare.subsmigrations.services.processeddocument",
+    properties: {
+      difference: Math.floor(
+        // Cosmos store ts in second so we need to translate in milliseconds
+        // eslint-disable-next-line no-underscore-dangle
+        new Date().getTime() - retrievedDocument._ts * 1000
+      ),
+      message: "Processed document",
+      serviceId: retrievedDocument.serviceId
+    },
+    tagOverrides: { samplingEnabled: "false" }
+  });
+};

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -7,7 +7,7 @@ import { initTelemetryClient } from "./appinsight";
  * @param telemetryClient
  * @returns
  */
-export const trackIgnoredInvalidIncomingDocument = (
+export const trackInvalidIncomingDocument = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
 ) => (
   d: unknown = {} /** default empty object to prevent nullish values */,
@@ -17,7 +17,6 @@ export const trackIgnoredInvalidIncomingDocument = (
     name: "selfcare.subsmigrations.services.invalid-incoming-document",
     properties: {
       documentId: (d as RetrievedService).id,
-      message: "Invalid document received",
       reason
     },
     tagOverrides: { samplingEnabled: "false" }
@@ -38,8 +37,7 @@ export const trackIgnoredIncomingDocument = (
   telemetryClient.trackEvent({
     name: "selfcare.subsmigrations.services.ignored-incoming-document",
     properties: {
-      documentId: (d as RetrievedService).id,
-      message: "Ignore document"
+      documentId: (d as RetrievedService).id
     },
     tagOverrides: { samplingEnabled: "false" }
   });
@@ -59,7 +57,6 @@ export const trackProcessedServiceDocument = (
     name: "selfcare.subsmigrations.services.processed-service",
     properties: {
       documentId: retrievedDocument.id,
-      message: "Processed document",
       serviceId: retrievedDocument.serviceId,
       // the time elapsed between when the doc has been created and when it has been processed
       timeDifference: Math.floor(

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -1,0 +1,29 @@
+import { RetrievedService } from "@pagopa/io-functions-commons/dist/src/models/service";
+import { initTelemetryClient } from "./appinsight";
+
+export const onInvalidDocument = (
+  telemetryClient: ReturnType<typeof initTelemetryClient>
+) => (d: unknown): void => {
+  telemetryClient.trackEvent({
+    name: "selfcare.subsmigrations.services.oninvaliddocument",
+    properties: {
+      documentId: (d as RetrievedService).serviceId,
+      message: "Invalid document received"
+    },
+    tagOverrides: { samplingEnabled: "false" }
+  });
+};
+
+export const onIgnoredDocument = (
+  telemetryClient: ReturnType<typeof initTelemetryClient>
+) => (d: unknown): void => {
+  telemetryClient.trackEvent({
+    name: "selfcare.subsmigrations.services.onignoredocument",
+    properties: {
+      documentId: (d as RetrievedService).serviceId,
+      message: "Ignore document"
+    },
+    tagOverrides: { samplingEnabled: "false" }
+  });
+  return void 0;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,6 +48,27 @@
     "@azure/logger" "^1.0.0"
     tslib "^2.2.0"
 
+"@azure/core-http@^2.2.3":
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-2.2.4.tgz#df5a5b4138dbbc4299879f2fc6f257d0a5f0401e"
+  integrity sha512-QmmJmexXKtPyc3/rsZR/YTLDvMatzbzAypJmLzvlfxgz/SkgnqV/D4f6F2LsK6tBj1qhyp8BoXiOebiej0zz3A==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-asynciterator-polyfill" "^1.0.0"
+    "@azure/core-auth" "^1.3.0"
+    "@azure/core-tracing" "1.0.0-preview.13"
+    "@azure/logger" "^1.0.0"
+    "@types/node-fetch" "^2.5.0"
+    "@types/tunnel" "^0.0.3"
+    form-data "^4.0.0"
+    node-fetch "^2.6.7"
+    process "^0.11.10"
+    tough-cookie "^4.0.0"
+    tslib "^2.2.0"
+    tunnel "^0.0.6"
+    uuid "^8.3.0"
+    xml2js "^0.4.19"
+
 "@azure/core-lro@^2.2.0":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@azure/core-lro/-/core-lro-2.2.3.tgz#3e245d37ede00f6410c1ea1fb76679dbdec627eb"
@@ -1091,6 +1112,40 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.2.tgz#921e1f2b2484b762d77225a8a25074482d93fccf"
   integrity sha512-DCF9oC89ao8/EJUqrp/beBlDR8Bp2R43jqtzayqCoomIvkwTuPfLcHdVhIGRR69GFlkykFjcDW+V92t0AS7Tww==
 
+"@opentelemetry/api@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.4.tgz#a167e46c10d05a07ab299fc518793b0cff8f6924"
+  integrity sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==
+
+"@opentelemetry/core@1.0.1", "@opentelemetry/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-1.0.1.tgz#5e08cef21946fdea7952f544e8f667f6d2a0ded8"
+  integrity sha512-90nQ2X6b/8X+xjcLDBYKooAcOsIlwLRYm+1VsxcX5cHl6V4CSVmDpBreQSDH/A21SqROzapk6813008SatmPpQ==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.0.1"
+
+"@opentelemetry/resources@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/resources/-/resources-1.0.1.tgz#2d190e2e6e64327b436447a8dd799afc673b6e07"
+  integrity sha512-p8DevOaAEepPucUtImR4cZKHOE2L1jgQAtkdZporV+XnxPA/HqCHPEESyUVuo4f5M0NUlL6k5Pba75KwNJlTRg==
+  dependencies:
+    "@opentelemetry/core" "1.0.1"
+    "@opentelemetry/semantic-conventions" "1.0.1"
+
+"@opentelemetry/sdk-trace-base@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.0.1.tgz#b88c72ac768eed58baab41552ce9070c57d5b7bf"
+  integrity sha512-JVSAepTpW7dnqfV7XFN0zHj1jXGNd5OcvIGQl76buogqffdgJdgJWQNrOuUJaus56zrOtlzqFH+YtMA9RGEg8w==
+  dependencies:
+    "@opentelemetry/core" "1.0.1"
+    "@opentelemetry/resources" "1.0.1"
+    "@opentelemetry/semantic-conventions" "1.0.1"
+
+"@opentelemetry/semantic-conventions@1.0.1", "@opentelemetry/semantic-conventions@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.0.1.tgz#9349c3860a53468fa2108b5df09aa843f22dbf94"
+  integrity sha512-7XU1sfQ8uCVcXLxtAHA8r3qaLJ2oq7sKtEwzZhzuEXqYmjW+n+J4yM3kNo0HQo3Xp1eUe47UM6Wy6yuAvIyllg==
+
 "@pagopa/danger-custom-rules@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@pagopa/danger-custom-rules/-/danger-custom-rules-2.0.3.tgz#0424cdb7bed9f256e4954604ae376ecdb6a4eb8d"
@@ -1377,6 +1432,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/node-fetch@^2.5.0":
+  version "2.5.12"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
+  integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node-fetch@^2.5.7":
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.7.tgz#20a2afffa882ab04d44ca786449a276f9f6bbf3c"
@@ -1453,6 +1516,13 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.1.tgz#8f80dd965ad81f3e1bc26d6f5c727e132721ff40"
   integrity sha512-Y0K95ThC3esLEYD6ZuqNek29lNX2EM1qxV8y2FTLUB0ff5wWrk7az+mLrnNFUnaXcgKye22+sFBRXOgpPILZNg==
+
+"@types/tunnel@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.3.tgz#f109e730b072b3136347561fc558c9358bb8c6e9"
+  integrity sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -1818,6 +1888,21 @@ applicationinsights@^1.8.10:
     continuation-local-storage "^3.2.1"
     diagnostic-channel "0.3.1"
     diagnostic-channel-publishers "0.4.4"
+
+applicationinsights@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.2.1.tgz#89d509b26a4f9dce6e3351da73061c986565d1b0"
+  integrity sha512-N6panMyjw6E6ayCgjFDBmL/NkaolgBgeX1iJ0jh50E6wrncVJBCa+I4IelwwOfJ4Dl9BWzOSLjp84wTiUyhNwg==
+  dependencies:
+    "@azure/core-http" "^2.2.3"
+    "@opentelemetry/api" "^1.0.4"
+    "@opentelemetry/core" "^1.0.1"
+    "@opentelemetry/sdk-trace-base" "^1.0.1"
+    "@opentelemetry/semantic-conventions" "^1.0.1"
+    cls-hooked "^4.2.2"
+    continuation-local-storage "^3.2.1"
+    diagnostic-channel "1.1.0"
+    diagnostic-channel-publishers "1.0.4"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -3240,10 +3325,22 @@ diagnostic-channel-publishers@0.4.4:
   resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.4.4.tgz#57c3b80b7e7f576f95be3a257d5e94550f0082d6"
   integrity sha512-l126t01d2ZS9EreskvEtZPrcgstuvH3rbKy82oUhUrVmBaGx4hO9wECdl3cvZbKDYjMF3QJDB5z5dL9yWAjvZQ==
 
+diagnostic-channel-publishers@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.4.tgz#29ef95ccd0a59cb4cb3b6aacb81d76adcbbc1737"
+  integrity sha512-GDRAOrcNTPk4DhYzM2BauMnq7nKdFWmSFjWnEu8dT8Xf/ZXUbpORrqNAhIWsy2tqRjHG7QkmYjMUL4/EGSM2GA==
+
 diagnostic-channel@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz#7faa143e107f861be3046539eb4908faab3f53fd"
   integrity sha512-6eb9YRrimz8oTr5+JDzGmSYnXy5V7YnK5y/hd8AUDK1MssHjQKm9LlD6NSrHx4vMDF3+e/spI2hmWTviElgWZA==
+  dependencies:
+    semver "^5.3.0"
+
+diagnostic-channel@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz#6985e9dfedfbc072d91dc4388477e4087147756e"
+  integrity sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==
   dependencies:
     semver "^5.3.0"
 
@@ -7989,6 +8086,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
 progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -8551,7 +8653,7 @@ sax@0.5.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@^1.2.1:
+sax@>=0.6.0, sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -9469,6 +9571,11 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
@@ -10084,10 +10191,23 @@ xml2js@0.2.8:
   dependencies:
     sax "0.5.x"
 
+xml2js@^0.4.19:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
 xmlbuilder@^9.0.7:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
In order to monitor some custom events, we add **Application Insight** to the function.

We plan to have this custom events:

* Ignore document because some documents doesn't need to migrate cause they already belong to an Organization;
* Process valid document with the difference between creation data from CosmosDB and creation data on PostreSQL
* Catch invalid document

This kind of events can be useful to have a Dashboard to monitoring migration process from a Delegate-based system  to an Organization-Oriented one.

---

Depends on https://github.com/pagopa/io-infra/pull/104