### PR TITLE
[#IC-282] Queue Handler ChangeAllSubscriptionsOwnership

### DIFF
--- a/ChangeAllSubscriptionsOwnership/__tests__/composeMessages.test.ts
+++ b/ChangeAllSubscriptionsOwnership/__tests__/composeMessages.test.ts
@@ -1,0 +1,28 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { composeMessages, SubscriptionResultRow } from "../handler";
+
+const mockSubscriptionsId: ReadonlyArray<SubscriptionResultRow> = [
+  {
+    subscriptionId: "1234" as NonEmptyString
+  },
+  {
+    subscriptionId: "3456" as NonEmptyString
+  },
+  {
+    subscriptionId: "7890" as NonEmptyString
+  }
+];
+
+const mockTargetId = "000000000" as NonEmptyString;
+
+describe("composeMessages", () => {
+  it("should receive an array of message and compost it", () => {
+    const expectedMessages = [
+      '{"subscriptionId":"1234","targetId":"000000000"}',
+      '{"subscriptionId":"3456","targetId":"000000000"}',
+      '{"subscriptionId":"7890","targetId":"000000000"}'
+    ];
+    const messages = composeMessages(mockSubscriptionsId, mockTargetId);
+    expect(messages).toEqual(expectedMessages);
+  });
+});

--- a/ChangeAllSubscriptionsOwnership/__tests__/createSelectSubscriptions.test.ts
+++ b/ChangeAllSubscriptionsOwnership/__tests__/createSelectSubscriptions.test.ts
@@ -4,7 +4,7 @@ import {
 } from "@pagopa/ts-commons/lib/strings";
 import { SubscriptionStatus } from "../../GetOwnershipClaimStatus/handler";
 import { IConfig } from "../../utils/config";
-import { selectSubscriptionsNotCompletedSql } from "../handler";
+import { createSelectSubscriptions } from "../handler";
 
 const mockDBConfig = {
   DB_SCHEMA: "Schema" as NonEmptyString,
@@ -13,7 +13,7 @@ const mockDBConfig = {
 
 describe("Generate Query string for get all subscriotions owned by sourceId belongs to an Organization", () => {
   it("should return a valid string as a select query", () => {
-    const query = selectSubscriptionsNotCompletedSql(mockDBConfig as IConfig)(
+    const query = createSelectSubscriptions(mockDBConfig as IConfig)(
       "12345678901" as OrganizationFiscalCode,
       "123" as NonEmptyString,
       SubscriptionStatus.COMPLETED

--- a/ChangeAllSubscriptionsOwnership/__tests__/getAllSubscriptionsAvailableToMigrate.test.ts
+++ b/ChangeAllSubscriptionsOwnership/__tests__/getAllSubscriptionsAvailableToMigrate.test.ts
@@ -1,0 +1,65 @@
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
+import { Pool, QueryResult } from "pg";
+import { IConfig } from "../../utils/config";
+import { getAllSubscriptionsAvailableToMigrate } from "../handler";
+import * as E from "fp-ts/lib/Either";
+
+/*
+This is a workaround to use Jest fail
+https://github.com/facebook/jest/issues/11698
+*/
+function fail(reason = "fail was called in a test.") {
+  throw new Error(reason);
+}
+
+const mockDBConfig = {
+  DB_HOST: "localhost" as NonEmptyString,
+  DB_IDLE_TIMEOUT: 3000,
+  DB_NAME: "test" as NonEmptyString,
+  DB_PASSWORD: "psw" as NonEmptyString,
+  DB_PORT: 5454,
+  DB_SCHEMA: "Schema" as NonEmptyString,
+  DB_TABLE: "Table" as NonEmptyString,
+  DB_USER: "User" as NonEmptyString
+};
+const mockQueryResult = {
+  command: "SELECT",
+  rowCount: 3,
+  rows: [
+    {
+      subscriptionId: "123"
+    },
+    {
+      subscriptionId: "456"
+    },
+    {
+      subscriptionId: "789"
+    }
+  ]
+} as QueryResult;
+const mockPool = {
+  query: jest.fn().mockImplementation(() => Promise.resolve(mockQueryResult))
+};
+
+describe("getAllSubscriptionsAvailableToMigrate", () => {
+  it("should return all subscriptions availate to migrate", async () => {
+    const expectedRes = [
+      { subscriptionId: "123" },
+      { subscriptionId: "456" },
+      { subscriptionId: "789" }
+    ];
+    const res = await getAllSubscriptionsAvailableToMigrate(
+      mockDBConfig as IConfig,
+      (mockPool as unknown) as Pool
+    )("00000000000" as OrganizationFiscalCode, "000" as NonEmptyString)();
+    if (E.isRight(res)) {
+      expect(res.right).toHaveProperty("rowCount", 3);
+      expect(res.right).toHaveProperty("rows", expectedRes);
+    } else {
+      fail("it fail to get a subscriptions available");
+    }
+  });
+});

--- a/ChangeAllSubscriptionsOwnership/__tests__/getTargetIdFromApim.test.ts
+++ b/ChangeAllSubscriptionsOwnership/__tests__/getTargetIdFromApim.test.ts
@@ -1,0 +1,66 @@
+import { getConfigOrThrow, IConfig } from "../../utils/config";
+import { getTargetIdFromAPIM } from "../handler";
+import {
+  EmailString,
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
+import { ApiManagementClient, UserContract } from "@azure/arm-apimanagement";
+import { ApimOrganizationUserResponse } from "../../models/DomainApimResponse";
+import * as E from "fp-ts/lib/Either";
+
+/*
+This is a workaround to use Jest fail
+https://github.com/facebook/jest/issues/11698
+*/
+function fail(reason = "fail was called in a test.") {
+  throw new Error(reason);
+}
+
+/*
+ * This function make an iterator with a raw user get from APIM
+ */
+function* makePagedAsyncIterableIterator() {
+  yield {
+    email: "email@test.test",
+    firstName: "FirstName Test",
+    id: "/subscriptions/subid/resourceGroups/resourceGroupName/providers/Microsoft.ApiManagement/service/apimServiceName/users/00000000000000000000000000" as NonEmptyString,
+    lastName: "Last Name Test",
+    note: "00000000000"
+  } as ApimOrganizationUserResponse;
+}
+
+// This need to return a valid UserContract structure and need to be an iterator with Organization UserContract
+const mockGetClient = () => ({
+  user: {
+    listByService: jest.fn(makePagedAsyncIterableIterator)
+  }
+});
+
+const mockApimClient = {
+  getClient: mockGetClient
+};
+
+describe("getTargetIdFromAPIM", () => {
+  it("should get a valid User from TargetId", async () => {
+    const expectedUser = {
+      email: "email@test.test",
+      firstName: "FirstName Test",
+      id:
+        "/subscriptions/subid/resourceGroups/resourceGroupName/providers/Microsoft.ApiManagement/service/apimServiceName/users/00000000000000000000000000",
+      lastName: "Last Name Test",
+      note: "00000000000",
+      kind: "organization"
+    };
+    const apimClient = (mockApimClient.getClient() as unknown) as ApiManagementClient;
+    const res = await getTargetIdFromAPIM(
+      {} as IConfig,
+      apimClient
+    )("00000000000" as OrganizationFiscalCode)();
+    if (E.isRight(res)) {
+      expect(res.right).toEqual(expectedUser);
+    } else {
+      fail("it fail to get a valid Organization user from APIM");
+    }
+  });
+});

--- a/ChangeAllSubscriptionsOwnership/__tests__/selectSubscriptionsNotCompletedSql.test.ts
+++ b/ChangeAllSubscriptionsOwnership/__tests__/selectSubscriptionsNotCompletedSql.test.ts
@@ -1,0 +1,24 @@
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
+import { SubscriptionStatus } from "../../GetOwnershipClaimStatus/handler";
+import { IConfig } from "../../utils/config";
+import { selectSubscriptionsNotCompletedSql } from "../handler";
+
+const mockDBConfig = {
+  DB_SCHEMA: "Schema" as NonEmptyString,
+  DB_TABLE: "Table" as NonEmptyString
+};
+
+describe("Generate Query string for get all subscriotions owned by sourceId belongs to an Organization", () => {
+  it("should return a valid string as a select query", () => {
+    const query = selectSubscriptionsNotCompletedSql(mockDBConfig as IConfig)(
+      "12345678901" as OrganizationFiscalCode,
+      "123" as NonEmptyString,
+      SubscriptionStatus.COMPLETED
+    );
+    const expected = `select "subscriptionId" from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "sourceId" = '123' and not "status" = 'COMPLETED'`;
+    expect(query).toBe(expected);
+  });
+});

--- a/ChangeAllSubscriptionsOwnership/__tests__/subscriptionMessageToQueue.test.ts
+++ b/ChangeAllSubscriptionsOwnership/__tests__/subscriptionMessageToQueue.test.ts
@@ -1,0 +1,18 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { subscriptionMessageToQueue } from "../handler";
+
+const mockSubscriptionId = "123" as NonEmptyString;
+const mockTargetId = "000" as NonEmptyString;
+describe("subscriptionMessageToQueue", () => {
+  it("should create a valid JSON stringify structure for queue message", () => {
+    const expectedMessage = JSON.stringify({
+      subscriptionId: "123",
+      targetId: "000"
+    });
+    const message = subscriptionMessageToQueue(
+      mockSubscriptionId,
+      mockTargetId
+    );
+    expect(message).toEqual(expectedMessage);
+  });
+});

--- a/ChangeAllSubscriptionsOwnership/function.json
+++ b/ChangeAllSubscriptionsOwnership/function.json
@@ -1,9 +1,9 @@
 {
   "bindings": [
      {
-      "queueName": "%QUEUE_ADD_SERVICE_TO_MIGRATIONS%",
+      "queueName": "%QUEUE_ALL_SUBSCRIPTIONS_TO_MIGRATE%",
       "connection": "INTERNAL_STORAGE_CONNECTION_STRING",
-      "name": "addservicejobs",
+      "name": "migrateallsubscriptionsjobs",
       "type": "queueTrigger",
       "direction": "in"
     },

--- a/ChangeAllSubscriptionsOwnership/function.json
+++ b/ChangeAllSubscriptionsOwnership/function.json
@@ -1,16 +1,16 @@
 {
   "bindings": [
      {
-      "queueName": "%QUEUE_ORGANIZATION_TO_MIGRATE%",
+      "queueName": "%QUEUE_ADD_SERVICE_TO_MIGRATIONS%",
       "connection": "INTERNAL_STORAGE_CONNECTION_STRING",
-      "name": "subscriptionToMigrate",
+      "name": "add-service-jobs",
       "type": "queueTrigger",
       "direction": "in"
     },
     {
       "queueName": "%QUEUE_SUBSCRIPTION_TO_MIGRATE%",
       "connection": "INTERNAL_STORAGE_CONNECTION_STRING",
-      "name": "subscriptionToMigrate",
+      "name": "migrate-one-subscription-jobs",
       "type": "queue",
       "direction": "out"
     }

--- a/ChangeAllSubscriptionsOwnership/function.json
+++ b/ChangeAllSubscriptionsOwnership/function.json
@@ -3,14 +3,14 @@
      {
       "queueName": "%QUEUE_ADD_SERVICE_TO_MIGRATIONS%",
       "connection": "INTERNAL_STORAGE_CONNECTION_STRING",
-      "name": "add-service-jobs",
+      "name": "addservicejobs",
       "type": "queueTrigger",
       "direction": "in"
     },
     {
       "queueName": "%QUEUE_SUBSCRIPTION_TO_MIGRATE%",
       "connection": "INTERNAL_STORAGE_CONNECTION_STRING",
-      "name": "migrate-one-subscription-jobs",
+      "name": "migrateonesubscriptionjobs",
       "type": "queue",
       "direction": "out"
     }

--- a/ChangeAllSubscriptionsOwnership/function.json
+++ b/ChangeAllSubscriptionsOwnership/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+     {
+      "queueName": "%QUEUE_ORGANIZATION_TO_MIGRATE%",
+      "connection": "INTERNAL_STORAGE_CONNECTION_STRING",
+      "name": "subscriptionToMigrate",
+      "type": "queueTrigger",
+      "direction": "in"
+    },
+    {
+      "queueName": "%QUEUE_SUBSCRIPTION_TO_MIGRATE%",
+      "connection": "INTERNAL_STORAGE_CONNECTION_STRING",
+      "name": "subscriptionToMigrate",
+      "type": "queue",
+      "direction": "out"
+    }
+  ],
+  "scriptFile": "../dist/ChangeOneSubscriptionOwnership/index.js",
+  "disabled": true
+}

--- a/ChangeAllSubscriptionsOwnership/handler.ts
+++ b/ChangeAllSubscriptionsOwnership/handler.ts
@@ -1,0 +1,76 @@
+import { ApiManagementClient } from "@azure/arm-apimanagement";
+import { pipe } from "fp-ts/lib/function";
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
+import * as TE from "fp-ts/lib/TaskEither";
+import { Pool } from "pg";
+import { Context } from "@azure/functions";
+import {
+  IConfig,
+  IDecodableConfigAPIM,
+  IDecodableConfigPostgreSQL
+} from "../utils/config";
+import { withJsonInput } from "../utils/misc";
+import { SubscriptionStatus } from "../GetOwnershipClaimStatus/handler";
+import { ClaimSubscriptionItem } from "./type";
+
+/*
+ * We need to generate a valid SQL string to get all subscription onwed by a sourceId and belongs to an Organization Fiscal Code where the status is not completed
+ */
+export const selectSubscriptionsNotCompletedSql = (
+  _dbConfig: IDecodableConfigPostgreSQL
+) => (
+  _organizationFiscalCode: OrganizationFiscalCode,
+  _sourceId: NonEmptyString,
+  _status: SubscriptionStatus
+): NonEmptyString => "Need to return a valid SQL" as NonEmptyString;
+
+/*
+ * The function gets all subscriptions available to migrate for the sourceId and organization fiscal code received from the queue message item
+ */
+export const getAllSubscriptionsAvailableToMigrate = (
+  _config: IConfig,
+  _pool: Pool
+) => (
+  _organizationFiscalCode: OrganizationFiscalCode
+): TE.TaskEither<unknown, unknown> =>
+  pipe(TE.throwError("Need to update Subscription Status on Database"));
+
+/*
+ * We need to retrieve target ID in full path from APIM needed to create the message queue for claim a single subscription
+ */
+export const getTargetIdFromAPIM = (
+  _config: IDecodableConfigAPIM,
+  _apimClient: ApiManagementClient
+) => (
+  _organizationFiscalCode: OrganizationFiscalCode
+): TE.TaskEither<unknown, unknown> => pipe(TE.throwError("To Be implemented"));
+
+/*
+ * Create a structure message to be inserted inside Queue
+ */
+export const subscriptionMessageToQueue = (
+  subscriptionId: NonEmptyString,
+  targetId: NonEmptyString
+): string =>
+  pipe(
+    { subscriptionId, targetId },
+    ClaimSubscriptionItem.encode,
+    JSON.stringify
+  );
+
+/*
+ * Receive a message and dispatch inside a Queue
+ */
+export const dispatchMigrationJobToQueue = (_context: Context) => (
+  _message: string
+): void => void 0;
+
+export const createHandler = (
+  _config: IConfig,
+  _apimClient: ApiManagementClient,
+  _pool: Pool
+): Parameters<typeof withJsonInput>[0] =>
+  withJsonInput(async (_context, _item): Promise<void> => void 0);

--- a/ChangeAllSubscriptionsOwnership/index.ts
+++ b/ChangeAllSubscriptionsOwnership/index.ts
@@ -1,0 +1,25 @@
+import { getConfigOrThrow } from "../utils/config";
+import getPool from "../utils/db";
+import { getApiClient } from "../utils/apim";
+import { createHandler } from "./handler";
+
+const config = getConfigOrThrow();
+// Setup PostgreSQL DB Pool
+const pool = getPool(config);
+// Get APIM Client
+const apimClient = getApiClient(
+  {
+    clientId: config.APIM_CLIENT_ID,
+    secret: config.APIM_SECRET,
+    tenantId: config.APIM_TENANT_ID
+  },
+  config.APIM_SUBSCRIPTION_ID
+);
+
+const handleChangeAllSubscriptionsOwnership = createHandler(
+  config,
+  apimClient,
+  pool
+);
+
+export default handleChangeAllSubscriptionsOwnership;

--- a/ChangeAllSubscriptionsOwnership/type.ts
+++ b/ChangeAllSubscriptionsOwnership/type.ts
@@ -1,0 +1,9 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as t from "io-ts";
+
+// The shape of the item expected in the queue
+export type ClaimSubscriptionItem = t.TypeOf<typeof ClaimSubscriptionItem>;
+export const ClaimSubscriptionItem = t.interface({
+  subscriptionId: NonEmptyString,
+  targetId: NonEmptyString
+});

--- a/ChangeAllSubscriptionsOwnership/type.ts
+++ b/ChangeAllSubscriptionsOwnership/type.ts
@@ -1,4 +1,7 @@
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";
 
 // The shape of the item expected in the queue
@@ -6,4 +9,13 @@ export type ClaimSubscriptionItem = t.TypeOf<typeof ClaimSubscriptionItem>;
 export const ClaimSubscriptionItem = t.interface({
   subscriptionId: NonEmptyString,
   targetId: NonEmptyString
+});
+
+// The shape of the item expected in the queue
+export type ClaimOrganizationSubscriptions = t.TypeOf<
+  typeof ClaimOrganizationSubscriptions
+>;
+export const ClaimOrganizationSubscriptions = t.interface({
+  organizationFiscalCode: OrganizationFiscalCode,
+  sourceId: NonEmptyString
 });


### PR DESCRIPTION
With this queue handler we can:

* receive a message from a Queue with OrganizationFiscalCode and SourceId
* retrieve targetId from APIM using note and OrganizationFiscalCode
* retrieve all the Subscriptions belongs to an Organization owned by a Source
* dispatch a message to a Queue with SubscriptionId and TargetId

Depends on https://github.com/pagopa/io-infra/pull/117