### PR TITLE
[IC-359] Show latest migration status belongs to an Organization

### DIFF
--- a/GetLatestMigrationsStatus/__tests__/handler.test.ts
+++ b/GetLatestMigrationsStatus/__tests__/handler.test.ts
@@ -1,0 +1,11 @@
+import { createHandler } from "../handler";
+
+describe("Create Handler Test", () => {
+  it("should return a Reponse Error Internal", async () => {
+    const handler = createHandler();
+
+    const response = await handler();
+
+    expect(response.kind).toBe("IResponseErrorInternal");
+  });
+});

--- a/GetLatestMigrationsStatus/__tests__/handler.test.ts
+++ b/GetLatestMigrationsStatus/__tests__/handler.test.ts
@@ -1,4 +1,20 @@
-import { createHandler } from "../handler";
+import {
+  NonEmptyString,
+  OrganizationFiscalCode
+} from "@pagopa/ts-commons/lib/strings";
+import { SubscriptionStatus } from "../../GetOwnershipClaimStatus/handler";
+import { createHandler, createSqlStatus } from "../handler";
+
+const mockDBConfig = {
+  DB_HOST: "localhost" as NonEmptyString,
+  DB_IDLE_TIMEOUT: 3000,
+  DB_NAME: "test" as NonEmptyString,
+  DB_PASSWORD: "psw" as NonEmptyString,
+  DB_PORT: 5454,
+  DB_SCHEMA: "TableSchema" as NonEmptyString,
+  DB_TABLE: "Table" as NonEmptyString,
+  DB_USER: "User" as NonEmptyString
+};
 
 describe("Create Handler Test", () => {
   it("should return a Reponse Error Internal", async () => {
@@ -7,5 +23,17 @@ describe("Create Handler Test", () => {
     const response = await handler();
 
     expect(response.kind).toBe("IResponseErrorInternal");
+  });
+});
+
+describe("Create SQL Query", () => {
+  it("should generate a valid SQL Query", () => {
+    const expectedSql = `select distinct "t"."sourceEmail", "t"."status" from "TableSchema"."Table" as "t" inner join (select "sourceEmail", max("updateAt") as "latestOp" from "TableSchema"."Table" where "organizationFiscalCode" = '12345678901' and not "status" = 'INITIAL' group by "sourceEmail") as "x" on "x"."sourceEmail" = "t"."sourceEmail" and "latestOp" = "t"."updateAt"`;
+    const sql = createSqlStatus(mockDBConfig)(
+      "12345678901" as OrganizationFiscalCode,
+      SubscriptionStatus.INITAL
+    );
+
+    expect(sql).toBe(expectedSql);
   });
 });

--- a/GetLatestMigrationsStatus/function.json
+++ b/GetLatestMigrationsStatus/function.json
@@ -1,0 +1,19 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "api/v1/organizations/{organizationFiscalCode}/latest-ownership-claims"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "../dist/GetLatestMigrationsStatus/index.js",
+   "disabled": true
+}

--- a/GetLatestMigrationsStatus/function.json
+++ b/GetLatestMigrationsStatus/function.json
@@ -6,7 +6,7 @@
       "direction": "in",
       "name": "req",
       "methods": ["get"],
-      "route": "api/v1/organizations/{organizationFiscalCode}/latest-ownership-claims"
+      "route": "api/v1/organizations/{organization_fiscal_code}/ownership-claims/latest"
     },
     {
       "type": "http",

--- a/GetLatestMigrationsStatus/handler.ts
+++ b/GetLatestMigrationsStatus/handler.ts
@@ -1,0 +1,47 @@
+import { ApiManagementClient } from "@azure/arm-apimanagement";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
+import { RequiredParamMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/required_param";
+import {
+  withRequestMiddlewares,
+  wrapRequestHandler
+} from "@pagopa/ts-commons/lib/request_middleware";
+import {
+  IResponseErrorInternal,
+  IResponseErrorNotFound,
+  IResponseSuccessJson,
+  ResponseErrorInternal
+} from "@pagopa/ts-commons/lib/responses";
+import { OrganizationFiscalCode } from "@pagopa/ts-commons/lib/strings";
+import * as express from "express";
+import { pipe } from "fp-ts/lib/function";
+import * as TE from "fp-ts/lib/TaskEither";
+import { MigrationsStatus } from "../generated/definitions/MigrationsStatus";
+import { IConfig } from "../utils/config";
+
+type Handler = () => Promise<
+  | IResponseSuccessJson<{ readonly data: MigrationsStatus }>
+  | IResponseErrorInternal
+  | IResponseErrorNotFound
+>;
+
+export const createHandler = (): Handler => (): ReturnType<Handler> =>
+  pipe(
+    TE.throwError<
+      string,
+      IResponseSuccessJson<{ readonly data: MigrationsStatus }>
+    >("To be Implementend"),
+    TE.mapLeft(ResponseErrorInternal),
+    TE.toUnion
+  )();
+
+export const getLatestMigrationsHandler = (
+  _config: IConfig,
+  _apimClient: ApiManagementClient
+): express.RequestHandler => {
+  const handler = createHandler();
+  const middlewaresWrap = withRequestMiddlewares(
+    ContextMiddleware(),
+    RequiredParamMiddleware("organizationFiscalCode", OrganizationFiscalCode)
+  );
+  return wrapRequestHandler(middlewaresWrap(handler));
+};

--- a/GetLatestMigrationsStatus/index.ts
+++ b/GetLatestMigrationsStatus/index.ts
@@ -1,0 +1,19 @@
+import { getConfigOrThrow } from "../utils/config";
+import { getApiClient } from "../utils/apim";
+import { getLatestMigrationsHandler } from "./handler";
+
+const config = getConfigOrThrow();
+
+// Get APIM Client
+const apimClient = getApiClient(
+  {
+    clientId: config.APIM_CLIENT_ID,
+    secret: config.APIM_SECRET,
+    tenantId: config.APIM_TENANT_ID
+  },
+  config.APIM_SUBSCRIPTION_ID
+);
+
+const handleServicesChange = getLatestMigrationsHandler(config, apimClient);
+
+export default handleServicesChange;

--- a/openapi/__tests__/index.test.ts
+++ b/openapi/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { Email } from "../../generated/definitions/Email";
 import { OrganizationDelegates } from "../../generated/definitions/OrganizationDelegates";
 import * as E from "fp-ts/lib/Either";
+import { MigrationsStatus } from "../../generated/definitions/MigrationsStatus";
 describe("Array Delegates", () => {
   it("should validate a valid Delegates response", () => {
     const delegates: OrganizationDelegates = [
@@ -14,6 +15,23 @@ describe("Array Delegates", () => {
     ];
 
     const res = OrganizationDelegates.decode(delegates);
+
+    expect(E.isRight(res)).toBe(true);
+  });
+
+  it("should validate a valid Latest Operation response", () => {
+    const operations: MigrationsStatus = [
+      {
+        sourceEmail: "test@email.com" as Email,
+        status: "PENDING"
+      },
+      {
+        sourceEmail: "test@email.com" as Email,
+        status: "COMPLETED"
+      }
+    ];
+
+    const res = MigrationsStatus.decode(operations);
 
     expect(E.isRight(res)).toBe(true);
   });

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -125,6 +125,10 @@ parameters:
     x-import: "@pagopa/ts-commons/lib/strings"
     required: true
 definitions:
+  MigrationsStatus:
+    type: array
+    items:
+      - $ref: "#/definitions/LatestOp"
   ClaimProcedureStatus:
     type: object
     properties:
@@ -153,6 +157,16 @@ definitions:
           - initial
           - processing
     required:
+      - status
+  LatestOp:
+    type: object
+    properties:
+      sourceEmail:
+        type: string
+      status:
+        type: string
+    required:
+      - sourceEmail
       - status
   Delegate:
     type: object

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -16,6 +16,30 @@ schemes:
 security:
   - SubscriptionKey: []
 paths:
+  /organizations/{organization_fiscal_code}/latest-ownership-claims:
+    get:
+      operationId: getLatestOwnershipClaimStatus
+      summary: Retrieve latest migrations status started by an Organization
+      description: >-
+        Given an Organization Fiscal Code a migrations status is returned in order to know which Delegate is migrated or in progession to be migrate.
+      parameters:
+        - $ref: "#/parameters/OrganizationFiscalCode"
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "#/definitions/ClaimProcedureStatus"
+        "400":
+          description: Bad Request
+        "401":
+          description: Unauthorized
+        "404":
+          description: >-
+            Access data provided are invalid or no row are presents in the database table
+        "500":
+          description: Generic server error
+          schema:
+            $ref: "#/definitions/ProblemJson"
   /organizations/{organization_fiscal_code}/ownership-claims/{delegate_id}:
     get:
       operationId: getOwnershipClaimStatus

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -16,7 +16,7 @@ schemes:
 security:
   - SubscriptionKey: []
 paths:
-  /organizations/{organization_fiscal_code}/latest-ownership-claims:
+  /organizations/{organization_fiscal_code}/ownership-claims/latest:
     get:
       operationId: getLatestOwnershipClaimStatus
       summary: Retrieve latest migrations status started by an Organization
@@ -28,7 +28,7 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: "#/definitions/ClaimProcedureStatus"
+            $ref: "#/definitions/MigrationsStatus"
         "400":
           description: Bad Request
         "401":


### PR DESCRIPTION
We should have a backend endpoint to retrieve latest migration operations started belongs to an Organization, so we can skip every migration with `status=initial`.
