### PR TITLE
Enable `ChangeAllSubscriptionsOwnership` hander

### DIFF
--- a/ChangeAllSubscriptionsOwnership/function.json
+++ b/ChangeAllSubscriptionsOwnership/function.json
@@ -15,6 +15,5 @@
       "direction": "out"
     }
   ],
-  "scriptFile": "../dist/ChangeOneSubscriptionOwnership/index.js",
-  "disabled": true
+  "scriptFile": "../dist/ChangeOneSubscriptionOwnership/index.js"
 }


### PR DESCRIPTION
Enable `ChangeAllSubscriptionsOwnership` hander to consume messages from `QUEUE_ALL_SUBSCRIPTIONS_TO_MIGRATE` job queue