### PR TITLE
[#IOPAE-57] Filter subscriptions to migrate

### DIFF
--- a/GetDelegatesByOrganization/__tests__/createSqlDelegates.test.ts
+++ b/GetDelegatesByOrganization/__tests__/createSqlDelegates.test.ts
@@ -17,7 +17,7 @@ const mockDBConfig = {
 
 describe("Create SQL for Delegates", () => {
   it("should generate a valid SQL", () => {
-    const expectedSql = `select "sourceId", "sourceName", "sourceSurname", "sourceEmail", count("subscriptionId") as "subscriptionCounter" from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "hasBeenVisibleOnce" = true group by "sourceId", "sourceName", "sourceSurname", "sourceEmail"`;
+    const expectedSql = `select "sourceId", "sourceName", "sourceSurname", "sourceEmail", count("subscriptionId") as "subscriptionCounter" from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "hasBeenVisibleOnce" = true and "serviceName" not ilike '%deleted%' group by "sourceId", "sourceName", "sourceSurname", "sourceEmail"`;
     const sql = createSqlDelegates(mockDBConfig)(
       "12345678901" as OrganizationFiscalCode
     );

--- a/GetDelegatesByOrganization/__tests__/createSqlDelegates.test.ts
+++ b/GetDelegatesByOrganization/__tests__/createSqlDelegates.test.ts
@@ -17,7 +17,7 @@ const mockDBConfig = {
 
 describe("Create SQL for Delegates", () => {
   it("should generate a valid SQL", () => {
-    const expectedSql = `select "sourceId", "sourceName", "sourceSurname", "sourceEmail", count("subscriptionId") as "subscriptionCounter" from "Schema"."Table" where "organizationFiscalCode" = '12345678901' group by "sourceId", "sourceName", "sourceSurname", "sourceEmail"`;
+    const expectedSql = `select "sourceId", "sourceName", "sourceSurname", "sourceEmail", count("subscriptionId") as "subscriptionCounter" from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "hasBeenVisibleOnce" = true group by "sourceId", "sourceName", "sourceSurname", "sourceEmail"`;
     const sql = createSqlDelegates(mockDBConfig)(
       "12345678901" as OrganizationFiscalCode
     );

--- a/GetDelegatesByOrganization/handler.ts
+++ b/GetDelegatesByOrganization/handler.ts
@@ -72,6 +72,8 @@ export const createSqlDelegates = (dbConfig: IDecodableConfigPostgreSQL) => (
     .where({ organizationFiscalCode })
     // ignore subs that has never been visible, probably tests or drafts that aren't worth being migrated
     .and.where({ hasBeenVisibleOnce: true })
+    // some subs have "deleted" in their name, we can skip them
+    .and.not.whereILike("serviceName", "%deleted%")
     .groupBy(["sourceId", "sourceName", "sourceSurname", "sourceEmail"])
     .toQuery() as NonEmptyString;
 

--- a/GetDelegatesByOrganization/handler.ts
+++ b/GetDelegatesByOrganization/handler.ts
@@ -70,6 +70,8 @@ export const createSqlDelegates = (dbConfig: IDecodableConfigPostgreSQL) => (
     .count("subscriptionId as subscriptionCounter")
     .from(dbConfig.DB_TABLE)
     .where({ organizationFiscalCode })
+    // ignore subs that has never been visible, probably tests or drafts that aren't worth being migrated
+    .and.where({ hasBeenVisibleOnce: true })
     .groupBy(["sourceId", "sourceName", "sourceSurname", "sourceEmail"])
     .toQuery() as NonEmptyString;
 

--- a/GetLatestMigrationsStatus/handler.ts
+++ b/GetLatestMigrationsStatus/handler.ts
@@ -81,6 +81,8 @@ export const createSqlStatus = (dbConfig: IDecodableConfigPostgreSQL) => (
     ])
     .from(`${dbConfig.DB_TABLE} as m`)
     .where({ organizationFiscalCode })
+    // ignore subs that has never been visible, probably tests or drafts that aren't worth being migrated
+    .and.where({ hasBeenVisibleOnce: true })
     .groupBy(["sourceId", "sourceName", "sourceSurname", "sourceEmail"])
     .having(
       // consider only delegates for which at least one migration has started

--- a/GetLatestMigrationsStatus/handler.ts
+++ b/GetLatestMigrationsStatus/handler.ts
@@ -83,6 +83,8 @@ export const createSqlStatus = (dbConfig: IDecodableConfigPostgreSQL) => (
     .where({ organizationFiscalCode })
     // ignore subs that has never been visible, probably tests or drafts that aren't worth being migrated
     .and.where({ hasBeenVisibleOnce: true })
+    // some subs have "deleted" in their name, we can skip them
+    .and.not.whereILike("serviceName", "%deleted%")
     .groupBy(["sourceId", "sourceName", "sourceSurname", "sourceEmail"])
     .having(
       // consider only delegates for which at least one migration has started


### PR DESCRIPTION
Migrating subscriptions is an opportunity for Organizations to clean up unwanted services, maybe test stuff created on early days. To do so, we don't consider migration for:
* services that have never been visible
* services that contain `deleted` in their name