### PR TITLE
[#IOPAE-64] Filter ownership claims to get only subscriptions that can migrate

### DIFF
--- a/ChangeAllSubscriptionsOwnership/__tests__/createSelectSubscriptions.test.ts
+++ b/ChangeAllSubscriptionsOwnership/__tests__/createSelectSubscriptions.test.ts
@@ -18,7 +18,7 @@ describe("Generate Query string for get all subscriotions owned by sourceId belo
       "123" as NonEmptyString,
       SubscriptionStatus.COMPLETED
     );
-    const expected = `select "subscriptionId" from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "sourceId" = '123' and not "status" = 'COMPLETED'`;
+    const expected = `select "subscriptionId" from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "hasBeenVisibleOnce" = true and "serviceName" not ilike '%deleted%' and "sourceId" = '123' and not "status" = 'COMPLETED'`;
     expect(query).toBe(expected);
   });
 });

--- a/ChangeAllSubscriptionsOwnership/handler.ts
+++ b/ChangeAllSubscriptionsOwnership/handler.ts
@@ -8,7 +8,6 @@ import * as E from "fp-ts/lib/Either";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as TE from "fp-ts/lib/TaskEither";
 import { Pool } from "pg";
-import knex from "knex";
 import * as t from "io-ts";
 import {
   IConfig,
@@ -27,6 +26,7 @@ import {
 } from "../models/DomainErrors";
 import { queryDataTable } from "../utils/db";
 import { ApimOrganizationUserResponse } from "../models/DomainApimResponse";
+import { MigrationsByOrganization } from "../utils/query";
 import { ClaimOrganizationSubscriptions, ClaimSubscriptionItem } from "./type";
 
 export const SubscriptionResultRow = t.interface({
@@ -50,14 +50,8 @@ export const createSelectSubscriptions = (
   sourceId: NonEmptyString,
   statusToExclude: SubscriptionStatus
 ): NonEmptyString =>
-  knex({
-    client: "pg"
-  })
-    .withSchema(dbConfig.DB_SCHEMA)
-    .table(dbConfig.DB_TABLE)
+  MigrationsByOrganization(dbConfig, organizationFiscalCode)
     .select("subscriptionId")
-    .from(dbConfig.DB_TABLE)
-    .where({ organizationFiscalCode })
     .and.where({ sourceId })
     .andWhereNot({ status: statusToExclude })
     .toQuery() as NonEmptyString;

--- a/ClaimOwnership/__tests__/updateAllStatusSubscriptionsSQL.test.ts
+++ b/ClaimOwnership/__tests__/updateAllStatusSubscriptionsSQL.test.ts
@@ -23,7 +23,7 @@ describe("UpdateSqlSubscription", () => {
       SubscriptionStatus.PROCESSING
     );
     expect(updateQuery).toBe(
-      `update "Schema"."Table" set "status" = 'PROCESSING' where "organizationFiscalCode" = '01234567890' and "sourceId" = '123' and "status" != 'COMPLETED'`
+      `update "Schema"."Table" set "status" = 'PROCESSING' where "organizationFiscalCode" = '01234567890' and "hasBeenVisibleOnce" = true and "serviceName" not ilike '%deleted%' and "sourceId" = '123' and "status" != 'COMPLETED'`
     );
   });
 });

--- a/ClaimOwnership/handler.ts
+++ b/ClaimOwnership/handler.ts
@@ -20,7 +20,6 @@ import {
 } from "@pagopa/ts-commons/lib/strings";
 import { Pool, QueryResult, QueryResultRow } from "pg";
 import { Context } from "@azure/functions";
-import { knex } from "knex";
 import { IConfig, IDecodableConfigPostgreSQL } from "../utils/config";
 import {
   IDbError,
@@ -30,8 +29,8 @@ import {
 import { SubscriptionStatus } from "../GetOwnershipClaimStatus/handler";
 import { queryDataTable } from "../utils/db";
 
-import { ClaimOrganizationSubscriptions } from "./types";
 import { MigrationsByOrganization } from "../utils/query";
+import { ClaimOrganizationSubscriptions } from "./types";
 
 type Handler = (
   context: Context,

--- a/ClaimOwnership/handler.ts
+++ b/ClaimOwnership/handler.ts
@@ -31,6 +31,7 @@ import { SubscriptionStatus } from "../GetOwnershipClaimStatus/handler";
 import { queryDataTable } from "../utils/db";
 
 import { ClaimOrganizationSubscriptions } from "./types";
+import { MigrationsByOrganization } from "../utils/query";
 
 type Handler = (
   context: Context,
@@ -48,16 +49,10 @@ export const generateUpdateSubscriptionStatusSQL = (
   sourceId: NonEmptyString,
   status: SubscriptionStatus
 ): NonEmptyString =>
-  knex({
-    client: "pg"
-  })
-    .withSchema(dbConfig.DB_SCHEMA)
-    .table(dbConfig.DB_TABLE)
-    .where({ organizationFiscalCode })
+  MigrationsByOrganization(dbConfig, organizationFiscalCode)
     .where({ sourceId })
     .where("status", "!=", SubscriptionStatus.COMPLETED)
     .update({ status })
-    .from(dbConfig.DB_TABLE)
     .toQuery() as NonEmptyString;
 
 export const updateSubscriptionStatus = (config: IConfig, connect: Pool) => (

--- a/GetDelegatesByOrganization/handler.ts
+++ b/GetDelegatesByOrganization/handler.ts
@@ -18,7 +18,6 @@ import {
   NonEmptyString,
   OrganizationFiscalCode
 } from "@pagopa/ts-commons/lib/strings";
-import knex from "knex";
 import { Pool } from "pg";
 import * as t from "io-ts";
 import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
@@ -33,6 +32,7 @@ import {
   toPostgreSQLErrorMessage
 } from "../models/DomainErrors";
 import { queryDataTable } from "../utils/db";
+import { MigrationsByOrganization } from "../utils/query";
 
 export const DelegateResultRow = t.interface({
   sourceEmail: EmailString,
@@ -61,19 +61,10 @@ type GetDelegatesByOrganizationResponseHandler = (
 export const createSqlDelegates = (dbConfig: IDecodableConfigPostgreSQL) => (
   organizationFiscalCode: OrganizationFiscalCode
 ): NonEmptyString =>
-  knex({
-    client: "pg"
-  })
-    .withSchema(dbConfig.DB_SCHEMA)
-    .table(dbConfig.DB_TABLE)
+  MigrationsByOrganization(dbConfig, organizationFiscalCode)
     .select(["sourceId", "sourceName", "sourceSurname", "sourceEmail"])
     .count("subscriptionId as subscriptionCounter")
-    .from(dbConfig.DB_TABLE)
-    .where({ organizationFiscalCode })
-    // ignore subs that has never been visible, probably tests or drafts that aren't worth being migrated
-    .and.where({ hasBeenVisibleOnce: true })
-    // some subs have "deleted" in their name, we can skip them
-    .and.not.whereILike("serviceName", "%deleted%")
+
     .groupBy(["sourceId", "sourceName", "sourceSurname", "sourceEmail"])
     .toQuery() as NonEmptyString;
 

--- a/GetLatestMigrationsStatus/__tests__/handler.test.ts
+++ b/GetLatestMigrationsStatus/__tests__/handler.test.ts
@@ -21,7 +21,10 @@ const mockDBConfig = {
   DB_TABLE: "Table" as NonEmptyString,
   DB_USER: "User" as NonEmptyString
 };
-const mockConfig = ({} as unknown) as IConfig;
+const mockConfig = ({
+  DB_SCHEMA: "mySchema",
+  DB_TABLE: "myTable"
+} as unknown) as IConfig;
 
 const mockQueryCommand = jest.fn().mockImplementation(async () => ({
   command: "SELECT",

--- a/GetOwnershipClaimStatus/__tests__/claimProcedureStatus.test.ts
+++ b/GetOwnershipClaimStatus/__tests__/claimProcedureStatus.test.ts
@@ -90,7 +90,7 @@ describe("createSql", () => {
     );
 
     expect(res).toBe(
-      `select "status", count("status") from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "sourceId" = '999' group by "status"`
+      `select "status", count("status") from "Schema"."Table" where "organizationFiscalCode" = '12345678901' and "hasBeenVisibleOnce" = true and "serviceName" not ilike '%deleted%' and "sourceId" = '999' group by "status"`
     );
   });
 });

--- a/GetOwnershipClaimStatus/handler.ts
+++ b/GetOwnershipClaimStatus/handler.ts
@@ -30,6 +30,7 @@ import {
   toPostgreSQLError,
   toPostgreSQLErrorMessage
 } from "../models/DomainErrors";
+import { MigrationsByOrganization } from "../utils/query";
 
 export const enum SubscriptionStatus {
   COMPLETED = "COMPLETED",
@@ -42,15 +43,9 @@ export const createSql = (dbConfig: IDecodableConfigPostgreSQL) => (
   organizationFiscalCode: OrganizationFiscalCode,
   sourceId: NonEmptyString
 ): NonEmptyString =>
-  knex({
-    client: "pg"
-  })
-    .withSchema(dbConfig.DB_SCHEMA)
-    .table(dbConfig.DB_TABLE)
+  MigrationsByOrganization(dbConfig, organizationFiscalCode)
     .select("status")
     .count("status")
-    .from(dbConfig.DB_TABLE)
-    .where({ organizationFiscalCode })
     .and.where({ sourceId })
     .groupBy("status")
     .toQuery() as NonEmptyString;

--- a/GetOwnershipClaimStatus/handler.ts
+++ b/GetOwnershipClaimStatus/handler.ts
@@ -21,7 +21,6 @@ import * as E from "fp-ts/Either";
 import * as TE from "fp-ts/TaskEither";
 import { flow, pipe } from "fp-ts/lib/function";
 import { Pool } from "pg";
-import knex from "knex";
 import { ClaimProcedureStatus } from "../generated/definitions/ClaimProcedureStatus";
 import { IConfig, IDecodableConfigPostgreSQL } from "../utils/config";
 import { queryDataTable, ResultRow, ResultSet } from "../utils/db";

--- a/utils/query.ts
+++ b/utils/query.ts
@@ -1,0 +1,31 @@
+import { OrganizationFiscalCode } from "@pagopa/ts-commons/lib/strings";
+import knexBase from "knex";
+import { IDecodableConfigPostgreSQL } from "./config";
+
+// set Postgres as default db target for the query builder
+const knex = knexBase({
+  client: "pg"
+});
+
+/**
+ * Query chunk filering migration table by a single organization
+ * Common filters are apllied, too
+ *
+ * @param dbConfig
+ * @param organizationFiscalCode
+ * @returns
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const MigrationsByOrganization = (
+  dbConfig: IDecodableConfigPostgreSQL,
+  organizationFiscalCode: OrganizationFiscalCode
+) =>
+  knex
+    .withSchema(dbConfig.DB_SCHEMA)
+    .table(dbConfig.DB_TABLE)
+    .from(`${dbConfig.DB_TABLE}`)
+    .where({ organizationFiscalCode })
+    // ignore subs that has never been visible, probably tests or drafts that aren't worth being migrated
+    .and.where({ hasBeenVisibleOnce: true })
+    // some subs have "deleted" in their name, we can skip them
+    .and.not.whereILike("serviceName", "%deleted%");


### PR DESCRIPTION
Apply same filters as in https://github.com/pagopa/io-subscription-migration/pull/44