### PR TITLE
[#IOPSC-111] Retry policy for change feed consumer

### DIFF
--- a/OnServiceChange/function.json
+++ b/OnServiceChange/function.json
@@ -20,5 +20,10 @@
       "direction": "out"
     }
   ],
+  "retry": {
+    "strategy": "fixedDelay",
+    "maxRetryCount": -1,
+    "delayInterval": "00:00:15"
+  },
   "scriptFile": "../dist/OnServiceChange/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "version": "auto-changelog -p --config .auto-changelog.json --unreleased && git add CHANGELOG.md"
   },
   "devDependencies": {
-    "@azure/functions": "^1.2.2",
+    "@azure/functions": "^3.2.0",
     "@pagopa/danger-custom-rules": "^2.0.3",
     "@pagopa/eslint-config": "^1.3.1",
     "@pagopa/openapi-codegen-ts": "^10.0.5",

--- a/utils/tracking.ts
+++ b/utils/tracking.ts
@@ -3,6 +3,9 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { DatabaseError } from "pg";
 import { initTelemetryClient } from "./appinsight";
 
+const eventName = (name: string): string =>
+  `selfcare.subsmigrations.services.${name}`;
+
 /**
  * Track when an incoming service document is invalid
  *
@@ -16,7 +19,7 @@ export const trackInvalidIncomingDocument = (
   reason: string = ""
 ): void => {
   telemetryClient.trackEvent({
-    name: "selfcare.subsmigrations.services.invalid-incoming-document",
+    name: eventName(`invalid-incoming-document`),
     properties: {
       documentId: (d as RetrievedService).id,
       reason
@@ -38,7 +41,7 @@ export const trackIgnoredIncomingDocument = (
   reason: string = ""
 ): void => {
   telemetryClient.trackEvent({
-    name: "selfcare.subsmigrations.services.ignored-incoming-document",
+    name: eventName(`ignored-incoming-document`),
     properties: {
       documentId: (d as RetrievedService).id,
       reason
@@ -58,7 +61,7 @@ export const trackProcessedServiceDocument = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
 ) => (retrievedDocument: RetrievedService): void => {
   telemetryClient.trackEvent({
-    name: "selfcare.subsmigrations.services.processed-service",
+    name: eventName(`processed-service`),
     properties: {
       documentId: retrievedDocument.id,
       serviceId: retrievedDocument.serviceId,
@@ -83,8 +86,7 @@ export const trackFailedQueryOnDocumentProcessing = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
 ) => (retrievedDocument: RetrievedService, error: DatabaseError): void => {
   telemetryClient.trackEvent({
-    name:
-      "selfcare.subsmigrations.services.failed-query-on-document-processing",
+    name: eventName(`processed-service.failed-query-on-document-processing`),
     properties: {
       documentId: retrievedDocument.id,
       errorMessage: error.message,
@@ -112,7 +114,7 @@ export const trackMigratedServiceDocument = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
 ) => (serviceId: NonEmptyString, targetId: NonEmptyString): void => {
   telemetryClient.trackEvent({
-    name: "selfcare.subsmigrations.services.migrated-service",
+    name: eventName(`migrated-service`),
     properties: {
       serviceId,
       targetId
@@ -131,7 +133,7 @@ export const trackFailedMigrationServiceDocument = (
   telemetryClient: ReturnType<typeof initTelemetryClient>
 ) => (serviceId: NonEmptyString, targetId: NonEmptyString): void => {
   telemetryClient.trackEvent({
-    name: "selfcare.subsmigrations.services.fail-migrated-service",
+    name: eventName(`fail-migrated-service`),
     properties: {
       serviceId,
       targetId

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,10 +149,15 @@
     universal-user-agent "^6.0.0"
     uuid "^8.3.0"
 
-"@azure/functions@^1.0.2-beta2", "@azure/functions@^1.2.2":
+"@azure/functions@^1.0.2-beta2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@azure/functions/-/functions-1.2.2.tgz#8fcb6aa3a879d3be0dc3d68919f969b054bbe3f3"
   integrity sha512-p/dDHq1sG/iAib+eDY4NxskWHoHW1WFzD85s0SfWxc2wVjJbxB0xz/zBF4s7ymjVgTu+0ceipeBk+tmpnt98oA==
+
+"@azure/functions@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@azure/functions/-/functions-3.2.0.tgz#c73003db8bd93be186824db29e98e00879bf0f91"
+  integrity sha512-HbE7iORnYcjLzKNf5mIQRJQDTsVxhoXHRWEZ6KWdGh4e7+F9xTloiBicavbSoVmlAYivenIVpryHanVwsQaHUw==
 
 "@azure/identity@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
Retry reading documents from change feed so that they are not dropped silently in case of error. `-1` means "retry forever".