### PR TITLE
[#IOPSC-110] Lower concurrency on queue message consuming

### DIFF
--- a/host.json
+++ b/host.json
@@ -18,7 +18,7 @@
       "routePrefix": ""
     },
     "queues": {
-      "batchSize": 4
+      "batchSize": 2
     }
   },
   "extensionBundle": {


### PR DESCRIPTION
Lower parallel job execution so that we don't press on APIM, which has a strict rate limit on its subscription API.

Setting `batchSize` to 2 means each instance of the app will process at most 3 queue item at a time.

Queue documentation: https://learn.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue?tabs=in-process%2Cextensionv5%2Cextensionv3&pivots=programming-language-javascript#host-json