### PR TITLE
[IOPAE-933] fix isOrganizationUser type-guard

### DIFF
--- a/models/DomainApimResponse.ts
+++ b/models/DomainApimResponse.ts
@@ -23,7 +23,14 @@ const isOrganizationUser = (u: RawApimUserResponse): boolean =>
       () => u.note !== undefined,
       () => E.toError
     ),
-    E.map(() => pipe(u.note.trim(), OrganizationFiscalCode.decode, E.isRight)),
+    E.map(() =>
+      pipe(
+        u.note.trim(),
+        OrganizationFiscalCode.decode,
+        E.orElse(() => pipe(u.firstName.trim(), OrganizationFiscalCode.decode)),
+        E.isRight
+      )
+    ),
     E.mapLeft(() => false),
     E.fold(() => false, identity)
   );


### PR DESCRIPTION
Patches code after changes that flipped values between `firstName` and `note` User Apim fields ([PR ref](https://github.com/pagopa/io-services-cms/pull/651))